### PR TITLE
"default" must be the last key in export maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./lib/index.min.js",
-        "types": "./lib/index.d.ts"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.min.js"
       },
       "types": {
         "import": {
-          "default": "./lib/index.d.ts",
-          "types": "./lib/index.d.ts"
+          "types": "./lib/index.d.ts",
+          "default": "./lib/index.d.ts"
         }
       }
     },
     "./full": {
       "import": {
-        "default": "./lib/index.js",
-        "types": "./lib/index.d.ts"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Closes #11

Issue has a bit more details, but the gist is that the "default" key must always be listed last in export maps and this is strictly enforced by tools like the Next.js buildchain.